### PR TITLE
🎉 Verify that AWS is configured before packaging app

### DIFF
--- a/app.js
+++ b/app.js
@@ -28,6 +28,8 @@ async function main () {
   const args = neodoc.run(usage)
   const spinner = ora()
 
+  amazon.verifyConfig()
+
   try {
     if (args.create) {
       spinner.start('Packaging app for Lambda')

--- a/lib/amazon.js
+++ b/lib/amazon.js
@@ -1,4 +1,5 @@
 const Lambda = require('aws-sdk/clients/lambda')
+const awsDefaultConfig = require('aws-sdk').config
 const APIGateway = require('aws-sdk/clients/apigateway')
 const IAM = require('aws-sdk/clients/iam')
 const parseArn = require('aws-arn-parser')
@@ -116,4 +117,8 @@ exports.createLambdaRole = async function (name) {
   await iam.attachRolePolicy(attachParams).promise()
 
   return result.Role.Arn
+}
+
+exports.verifyConfig = function () {
+  if (!awsDefaultConfig.region) throw new Error('Missing AWS_REGION in environment')
 }


### PR DESCRIPTION
Until https://github.com/aws/aws-sdk-js/issues/1921 is fixed or we start reading the config file manually, `AWS_REGION` must be set for aws-sdk to know where to deploy the lambda functions, better to throw early than to let the user sit trough a successful deploy only to know that they need to set the region 👍 