### PR TITLE
Fix cleanup for yarn

### DIFF
--- a/lib/dockerfile.js
+++ b/lib/dockerfile.js
@@ -38,7 +38,11 @@ exports.generate = function (options) {
 
   // Add the app files, and remove our special files
   lines.push('COPY . .')
-  lines.push('RUN rm scandium-clean-package.json scandium-clean-package-lock.json scandium-dockerfile')
+  if (yarn) {
+    lines.push('RUN rm scandium-clean-package.json scandium-dockerfile')
+  } else {
+    lines.push('RUN rm scandium-clean-package.json scandium-clean-package-lock.json scandium-dockerfile')
+  }
 
   // Run the `prepare` script, if present
   if (prepare) lines.push('RUN npm run-script prepare')


### PR DESCRIPTION
scandium-clean-package-lock.json does not exist in non npm builds