### PR TITLE
💥 Respect "main" entry in package.json

### DIFF
--- a/entrypoint.js
+++ b/entrypoint.js
@@ -173,4 +173,4 @@ exports.handler = function (event, context, cb) {
 }
 
 // Start the actual app
-require('./index')
+require('./')


### PR DESCRIPTION
Migration Guide:

If you previously relied on the fact that Scandium would always pick "index.js" as the entry point instead of respecting the `"main"` field of `package.json`, you need to update your `"main"` field to point to the correct file. If the `"main"` field isn't present, it still defaults to `index.js`.