### PR TITLE
🐛 Account for base-64 overhead in maxBuffer

### DIFF
--- a/lib/builder.js
+++ b/lib/builder.js
@@ -67,7 +67,7 @@ exports.createZipFile = async function (directory) {
   cleanup()
   removeUnloadCleanupHandler()
 
-  const zipFile = await execa.stdout('docker', ['run', '--rm', imageId], { maxBuffer: bytes.parse('100mb') })
+  const zipFile = await execa.stdout('docker', ['run', '--rm', imageId], { maxBuffer: bytes.parse('134mb') })
 
   return Buffer.from(zipFile, 'base64')
 }


### PR DESCRIPTION
The largest zip files allowed are 100mb, but when base64 encoding a zip file of that size would be ~133.33mb. This patch bumps the maximum buffer size to 134mb to account for that.