### PR TITLE
Initial worker options

### DIFF
--- a/app.js
+++ b/app.js
@@ -36,6 +36,8 @@ options:
   --version                    Print the current version of Scandium, then exit.
   --output=<path>              Output built zip. Example: "--output scandium.zip"
   --bucket=<name>              Use S3 bucket for deployment, needed for deployments over 50MB.
+  --handler=<name>             Use custom handler instead of scandium http handler
+  --worker                     Deploy lambda function as worker (no http)
 `
 
 async function main () {

--- a/lib/amazon.js
+++ b/lib/amazon.js
@@ -46,11 +46,11 @@ exports.verifyCodeSize = function (zipFile, { usingS3 }) {
   if (zipFile.byteLength >= fileSizeLimit) throw new Error(`Code size exceeded, ${bytes.format(zipFile.byteLength)}, max zip size for ${codeStorageName} deployments is ${bytes.format(fileSizeLimit)}${hint}`)
 }
 
-exports.createFunction = function ({ code, functionName, role, environment, onFailedAttempt }) {
+exports.createFunction = function ({ code, functionName, role, environment, onFailedAttempt, handler }) {
   const params = {
     Code: code,
     FunctionName: functionName,
-    Handler: 'scandium-entrypoint.handler',
+    Handler: handler,
     MemorySize: defaultParams.MemorySize,
     Publish: true,
     Role: role,
@@ -71,10 +71,11 @@ function updateRuntime ({ functionName }) {
   return lambda.updateFunctionConfiguration(params).promise().then(res => res.FunctionArn)
 }
 
-exports.updateFunction = async function ({ code, functionName }) {
+exports.updateFunction = async function ({ code, functionName, handler }) {
   const params = {
     FunctionName: functionName,
     Publish: true,
+    Handler: handler,
     ...code
   }
 

--- a/lib/tasks.js
+++ b/lib/tasks.js
@@ -55,6 +55,12 @@ exports.parseOptions = {
       amendObject(ctx.environment, ctx.args['--env'].map(parseKeyValuePair))
     }
 
+    if (ctx.args['--handler']) {
+      ctx.handler = ctx.args['--handler']
+    } else {
+      ctx.handler = 'scandium-entrypoint.handler'
+    }
+
     if (ctx.args['--output']) {
       ctx.outputPath = path.resolve(ctx.args['--output'])
     }
@@ -139,7 +145,7 @@ exports.createLambdaFunction = {
     const onFailedAttempt = (error) => {
       task.title = `Attempt ${error.attemptNumber} failed. There are ${error.attemptsLeft} attempts left.`
     }
-    ctx.lambdaArn = await amazon.createFunction({ code: ctx.code, functionName: ctx.name, role: ctx.roleArn, environment: ctx.environment, onFailedAttempt })
+    ctx.lambdaArn = await amazon.createFunction({ code: ctx.code, functionName: ctx.name, role: ctx.roleArn, environment: ctx.environment, onFailedAttempt, handler: ctx.handler })
     task.title = `Created new Lambda function with ARN: ${ctx.lambdaArn}`
   }
 }
@@ -148,7 +154,7 @@ exports.updateLambdaFunction = {
   title: 'Updating Lambda function',
   task: async (ctx, task) => {
     try {
-      ctx.lambdaArn = await amazon.updateFunction({ code: ctx.code, functionName: ctx.name })
+      ctx.lambdaArn = await amazon.updateFunction({ code: ctx.code, functionName: ctx.name, handler: ctx.handler })
       task.title = `Updated existing Lambda function with ARN: ${ctx.lambdaArn}`
     } catch (err) {
       if (err.code === 'ResourceNotFoundException') {
@@ -202,6 +208,7 @@ exports.generateSwaggerDefinition = {
 
 exports.createApiGateway = {
   title: 'Creating new API Gateway',
+  enabled: (ctx) => !Boolean(ctx.args['--worker']),
   task: async (ctx, task) => {
     if (ctx.args['--rest-api-id']) {
       ctx.id = ctx.args['--rest-api-id']
@@ -215,6 +222,7 @@ exports.createApiGateway = {
 
 exports.updateApiGateway = {
   title: 'Updating existing API Gateway',
+  enabled: (ctx) => !Boolean(ctx.args['--worker']),
   task: async (ctx, task) => {
     if (ctx.args['--rest-api-id']) {
       ctx.id = ctx.args['--rest-api-id']
@@ -229,7 +237,7 @@ exports.updateApiGateway = {
 
 exports.deployApi = {
   title: 'Deploying the API to a live address',
-  enabled: (ctx) => Boolean(ctx.apiGatewayStage),
+  enabled: (ctx) => Boolean(ctx.apiGatewayStage) && !Boolean(ctx.args['--worker']),
   task: async (ctx, task) => {
     const stage = ctx.apiGatewayStage
     const { region } = parseArn(ctx.lambdaArn)


### PR DESCRIPTION
This adds two parameters:

`--handler` - set custom lambda handler, eg `--handler=index.handler`
`--worker` - disable api gateway and swagger stuff


example

`scandium update --handler=index.handler --worker`