### PR TITLE
🎉 Add --ssh-key arg to pass SSH keys to builder

### DIFF
--- a/app.js
+++ b/app.js
@@ -36,6 +36,7 @@ options:
   --version                    Print the current version of Scandium, then exit.
   --output=<path>              Output built zip. Example: "--output scandium.zip"
   --bucket=<name>              Use S3 bucket for deployment, needed for deployments over 50MB.
+  --ssh-key=<path>             Use the specified SSH key when installing dependencies.
 `
 
 async function main () {

--- a/lib/builder.js
+++ b/lib/builder.js
@@ -1,3 +1,4 @@
+const fs = require('fs')
 const path = require('path')
 
 const bytes = require('bytes')
@@ -23,7 +24,7 @@ function loadGitignoreFile (path) {
 
 const DEFAULT_IGNORE = ['.git/', 'node_modules/'].join('\n') + '\n'
 
-exports.createZipFile = async function (directory) {
+exports.createZipFile = async function (directory, { sshKey }) {
   const cleanupFiles = []
   const cleanup = () => cleanupFiles.map(file => path.join(directory, file)).forEach(rmFile.sync)
   const removeUnloadCleanupHandler = unload.add(cleanup)
@@ -37,7 +38,7 @@ exports.createZipFile = async function (directory) {
   const cleanPackageLock = hasYarnLockfile ? null : Object.assign({}, packageLock, { version: '0.0.0' })
 
   const hasPrepare = (packageInfo.scripts && packageInfo.scripts.prepare)
-  const dockerfileSource = dockerfile.generate({ prepare: hasPrepare, yarn: hasYarnLockfile })
+  const dockerfileSource = dockerfile.generate({ prepare: hasPrepare, sshKey: Boolean(sshKey), yarn: hasYarnLockfile })
 
   const hasDockerignore = await pathExists(path.join(directory, '.dockerignore'))
   const hasGitignore = await pathExists(path.join(directory, '.gitignore'))
@@ -62,7 +63,14 @@ exports.createZipFile = async function (directory) {
     cleanupFiles.push('.dockerignore')
   }
 
-  const imageId = await execa.stdout('docker', ['build', '--quiet', '--file', 'scandium-dockerfile', '.'], { cwd: directory })
+  let imageId
+  if (sshKey) {
+    const sshKeyPrivate = fs.readFileSync(sshKey).toString('base64')
+    const sshKeyPublic = fs.readFileSync(`${sshKey}.pub`).toString('base64')
+    imageId = await execa.stdout('docker', ['build', '--quiet', '--build-arg', 'SSH_PRIVATE_KEY', '--build-arg', 'SSH_PUBLIC_KEY', '--file', 'scandium-dockerfile', '.'], { cwd: directory, env: { SSH_PRIVATE_KEY: sshKeyPrivate, SSH_PUBLIC_KEY: sshKeyPublic } })
+  } else {
+    imageId = await execa.stdout('docker', ['build', '--quiet', '--file', 'scandium-dockerfile', '.'], { cwd: directory })
+  }
 
   cleanup()
   removeUnloadCleanupHandler()

--- a/lib/dockerfile.js
+++ b/lib/dockerfile.js
@@ -1,11 +1,16 @@
+const githubPublicKey = 'github.com ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ=='
+const sshPostfix = ' && unlink $HOME/.ssh/id_rsa && unlink $HOME/.ssh/id_rsa.pub'
+const sshPrefix = 'echo $SSH_PRIVATE_KEY | base64 --decode > $HOME/.ssh/id_rsa && chmod 0600 $HOME/.ssh/id_rsa && echo $SSH_PUBLIC_KEY | base64 --decode > $HOME/.ssh/id_rsa.pub && '
+
 /**
  * @param {object} options
  * @param {boolean} options.prepare
+ * @param {boolean} options.sshKey
  * @param {boolean} options.yarn
  * @returns {string}
  */
 exports.generate = function (options) {
-  const { prepare, yarn } = options
+  const { prepare, sshKey, yarn } = options
   const lines = []
 
   // Base image on Amazon Linux
@@ -28,13 +33,16 @@ exports.generate = function (options) {
   lines.push('COPY scandium-clean-package.json package.json')
   lines.push(`COPY ${yarn ? 'yarn.lock yarn.lock' : 'scandium-clean-package-lock.json package-lock.json'}`)
 
+  // Add build argument for SSH key, and prime known_hosts with GitHub public key
+  if (sshKey) lines.push('ARG SSH_PRIVATE_KEY', 'ARG SSH_PUBLIC_KEY', `RUN mkdir -p $HOME/.ssh && echo "${githubPublicKey}" >> $HOME/.ssh/known_hosts`)
+
   // Add production dependencies
   // This step is run before adding the code, to increase docker cache use.
-  lines.push(`RUN ${yarn ? 'yarn' : 'npm'} install --production`)
+  lines.push(`RUN ${sshKey ? sshPrefix : ''}${yarn ? 'yarn' : 'npm'} install --production${sshKey ? sshPostfix : ''}`)
   lines.push('RUN zip -9qyr /output.zip node_modules')
 
   // Install dev-dependencies, if there is a `prepare` script present
-  if (prepare) lines.push(`RUN ${yarn ? 'yarn' : 'npm'} install`)
+  if (prepare) lines.push(`RUN ${sshKey ? sshPrefix : ''}${yarn ? 'yarn' : 'npm'} install${sshKey ? sshPostfix : ''}`)
 
   // Add the app files, and remove our special files
   lines.push('COPY . .')

--- a/lib/tasks.js
+++ b/lib/tasks.js
@@ -62,6 +62,10 @@ exports.parseOptions = {
     if (ctx.args['--bucket']) {
       ctx.bucket = ctx.args['--bucket']
     }
+
+    if (ctx.args['--ssh-key']) {
+      ctx.sshKey = ctx.args['--ssh-key']
+    }
   }
 }
 
@@ -76,7 +80,7 @@ exports.packageApp = {
     }
 
     try {
-      ctx.code = { ZipFile: await builder.createZipFile(process.cwd()) }
+      ctx.code = { ZipFile: await builder.createZipFile(process.cwd(), { sshKey: ctx.sshKey }) }
     } finally {
       if (ticker) clearInterval(ticker)
     }


### PR DESCRIPTION
This is primarily intended when having GitHub-dependencies in your `package.json`, passing this flag will make sure that it "just works"