### PR TITLE
💥 Enforce lockfiles

### DIFF
--- a/lib/dockerfile.js
+++ b/lib/dockerfile.js
@@ -20,7 +20,8 @@ exports.generate = function (options) {
   lines.push('RUN yum install -y gcc gcc-c++ git make openssl-devel zip')
   lines.push('RUN curl https://nodejs.org/download/release/v8.10.0/node-v8.10.0-linux-x64.tar.gz | tar xz -C /usr --strip-components=1')
 
-  // Install Yarn, if neccessary
+  // Install package managers
+  lines.push('RUN npm install -g npm@6.4.1')
   if (yarn) lines.push('RUN npm install -g yarn')
 
   // Set the workdir to same directory as Lambdas executes in
@@ -38,11 +39,11 @@ exports.generate = function (options) {
 
   // Add production dependencies
   // This step is run before adding the code, to increase docker cache use.
-  lines.push(`RUN ${sshKey ? sshPrefix : ''}${yarn ? 'yarn' : 'npm'} install --production${sshKey ? sshPostfix : ''}`)
+  lines.push(`RUN ${sshKey ? sshPrefix : ''}${yarn ? 'yarn install --production --frozen-lockfile' : 'npm ci --production'}${sshKey ? sshPostfix : ''}`)
   lines.push('RUN zip -9qyr /output.zip node_modules')
 
   // Install dev-dependencies, if there is a `prepare` script present
-  if (prepare) lines.push(`RUN ${sshKey ? sshPrefix : ''}${yarn ? 'yarn' : 'npm'} install${sshKey ? sshPostfix : ''}`)
+  if (prepare) lines.push(`RUN ${sshKey ? sshPrefix : ''}${yarn ? 'yarn install --frozen-lockfile' : 'npm ci'}${sshKey ? sshPostfix : ''}`)
 
   // Add the app files, and remove our special files
   lines.push('COPY . .')


### PR DESCRIPTION
Migration Guide:

Scandium will now refuse to build your app if your package-lock.json or yarn.lock file is out of sync. Make sure that they are in sync with your package.json file.