### PR TITLE
💥 Upgrade to Node.js 12.x

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/node:10
+      - image: circleci/node:12
     steps:
       - checkout
       - run: npm install

--- a/lib/amazon.js
+++ b/lib/amazon.js
@@ -21,7 +21,7 @@ const MAX_S3_ZIP_SIZE = bytes.parse('100mb')
 const defaultParams = {
   MemorySize: 320,
   Timeout: 3,
-  Runtime: 'nodejs10.x'
+  Runtime: 'nodejs12.x'
 }
 
 function addPermission ({ lambdaArn, restApiId }) {

--- a/lib/dockerfile.js
+++ b/lib/dockerfile.js
@@ -16,15 +16,15 @@ exports.generate = function (options) {
   const lines = []
 
   // Base image on Amazon Linux
-  lines.push('FROM amazonlinux:2.0.20190823.1')
+  lines.push('FROM amazonlinux:2.0.20191217.0')
 
   // Install prerequisites
   lines.push('RUN yum install -y gcc gcc-c++ git make openssl-devel tar zip')
-  lines.push('RUN curl https://nodejs.org/download/release/v10.16.3/node-v10.16.3-linux-x64.tar.gz | tar xz -C /usr --strip-components=1')
+  lines.push('RUN curl https://nodejs.org/download/release/v12.13.0/node-v12.13.0-linux-x64.tar.gz | tar xz -C /usr --strip-components=1')
 
   // Install package managers
-  lines.push('RUN npm install -g npm@6.9.0')
-  if (yarn) lines.push('RUN npm install -g yarn@1.19.0')
+  lines.push('RUN npm install -g npm@6.12.0')
+  if (yarn) lines.push('RUN npm install -g yarn@1.21.1')
 
   // Set the workdir to same directory as Lambdas executes in
   // Some tools, e.g. Next.js, hard codes the path during the build phase.


### PR DESCRIPTION
Migration Guide:

Make sure that your app is compatible with Node.js 12.x before upgrading to this version.