### PR TITLE
💥 Upgrade to Node.js 14.x

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/node:12
+      - image: circleci/node:14
     steps:
       - checkout
       - run: npm install

--- a/lib/amazon.js
+++ b/lib/amazon.js
@@ -21,7 +21,7 @@ const MAX_S3_ZIP_SIZE = bytes.parse('100mb')
 const defaultParams = {
   MemorySize: 320,
   Timeout: 3,
-  Runtime: 'nodejs12.x'
+  Runtime: 'nodejs14.x'
 }
 
 function addPermission ({ lambdaArn, restApiId }) {

--- a/lib/dockerfile.js
+++ b/lib/dockerfile.js
@@ -16,14 +16,14 @@ exports.generate = function (options) {
   const lines = []
 
   // Base image on Amazon Linux
-  lines.push('FROM amazonlinux:2.0.20201218.1')
+  lines.push('FROM amazonlinux:2.0.20210326.0')
 
   // Install prerequisites
   lines.push('RUN yum install -y gcc gcc-c++ git make openssl-devel tar zip')
-  lines.push('RUN curl https://nodejs.org/download/release/v12.20.1/node-v12.20.1-linux-x64.tar.gz | tar xz -C /usr --strip-components=1')
+  lines.push('RUN curl https://nodejs.org/download/release/v14.16.0/node-v14.16.0-linux-x64.tar.gz | tar xz -C /usr --strip-components=1')
 
   // Install package managers
-  lines.push('RUN npm install -g npm@6.14.10')
+  lines.push('RUN npm install -g npm@6.14.11')
   if (yarn) lines.push('RUN npm install -g yarn@1.22.10')
 
   // Set the workdir to same directory as Lambdas executes in


### PR DESCRIPTION
Migration Guide:

Make sure that your app is compatible with Node.js 14.x before upgrading to this version.