### PR TITLE
💥 Use "npm pack" to generate file list

### DIFF
--- a/lib/dockerfile.js
+++ b/lib/dockerfile.js
@@ -2,6 +2,19 @@ const githubPublicKey = 'github.com ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGm
 const sshPostfix = ' && unlink $HOME/.ssh/id_rsa && unlink $HOME/.ssh/id_rsa.pub'
 const sshPrefix = 'echo $SSH_PRIVATE_KEY | base64 --decode > $HOME/.ssh/id_rsa && chmod 0600 $HOME/.ssh/id_rsa && echo $SSH_PUBLIC_KEY | base64 --decode > $HOME/.ssh/id_rsa.pub && '
 
+const listNpmPackFiles = (
+  // Run "npm pack" and parse output
+  'JSON.parse(child_process.execSync("npm pack --dry-run --json").toString())' +
+  // Extract list of files from output
+  '[0].files.map(file => file.path)' +
+  // Remove "scandium-entrypoint.js" if it exists
+  '.filter(path => path !== "scandium-entrypoint.js")' +
+  // Always add back "scandium-entrypoint.js"
+  '.concat(["scandium-entrypoint.js"])' +
+  // Output one line per file
+  '.join("\\n")'
+)
+
 /**
  * @param {object} options
  * @param {boolean} options.hasBuildScript
@@ -61,8 +74,7 @@ exports.generate = function (options) {
   else if (hasBuildScript) lines.push('RUN npm run-script build')
 
   // Add the local code to the zip
-  lines.push('RUN rm -r node_modules')
-  lines.push('RUN zip -9qyrg /output.zip .')
+  lines.push(`RUN node -p '${listNpmPackFiles}' | zip -9qyrg@ /output.zip`)
 
   // Give the zip to the caller
   lines.push('CMD cat /output.zip | base64')


### PR DESCRIPTION
Migration Guide:

The list of files to include in the Lambda bundle is now handled by "npm pack", instead of just adding all files. If you were previously relying on files being ignored by npm, these files will no longer be bundled. Tweak your `package.json` `"files"` field or `.npmignore` file accordingly.