### PR TITLE
💥 Convert package to ESM

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,8 +1,5 @@
 #!/usr/bin/env node
 
-/* Make sure that AWS uses local config files, since this is a CLI util */
-process.env.AWS_SDK_LOAD_CONFIG = 'true'
-
 const isCI = require('is-ci')
 const Listr = require('listr')
 const listrVerboseRenderer = require('listr-verbose-renderer')

--- a/app.js
+++ b/app.js
@@ -1,12 +1,12 @@
 #!/usr/bin/env node
 
-const isCI = require('is-ci')
-const Listr = require('listr')
-const listrVerboseRenderer = require('listr-verbose-renderer')
-const neodoc = require('neodoc')
+import isCI from 'is-ci'
+import Listr from 'listr'
+import listrVerboseRenderer from 'listr-verbose-renderer'
+import neodoc from 'neodoc'
 
-const tasks = require('./lib/tasks')
-const UserError = require('./lib/user-error')
+import * as tasks from './lib/tasks.js'
+import UserError from './lib/user-error.js'
 
 const usage = `
 Scandium

--- a/lib/amazon.js
+++ b/lib/amazon.js
@@ -1,15 +1,15 @@
-const { APIGatewayClient, CreateDeploymentCommand: CreateDeploymentCommandV1, PutRestApiCommand } = require('@aws-sdk/client-api-gateway')
-const { ApiGatewayV2Client, CreateDeploymentCommand: CreateDeploymentCommandV2, CreateStageCommand, GetApisCommand, ImportApiCommand, ReimportApiCommand } = require('@aws-sdk/client-apigatewayv2')
-const { AttachRolePolicyCommand, CreateRoleCommand, IAMClient } = require('@aws-sdk/client-iam')
-const { AddPermissionCommand, CreateFunctionCommand, GetFunctionConfigurationCommand, InvokeCommand, LambdaClient, UpdateFunctionCodeCommand, UpdateFunctionConfigurationCommand } = require('@aws-sdk/client-lambda')
-const { PutObjectCommand, S3Client } = require('@aws-sdk/client-s3')
-const bytes = require('bytes')
-const parseArn = require('aws-arn-parser')
-const { nanoid } = require('nanoid')
-const pRetry = require('p-retry')
-const revHash = require('rev-hash')
+import { APIGatewayClient, CreateDeploymentCommand as CreateDeploymentCommandV1, PutRestApiCommand } from '@aws-sdk/client-api-gateway'
+import { ApiGatewayV2Client, CreateDeploymentCommand as CreateDeploymentCommandV2, CreateStageCommand, GetApisCommand, ImportApiCommand, ReimportApiCommand } from '@aws-sdk/client-apigatewayv2'
+import { AttachRolePolicyCommand, CreateRoleCommand, IAMClient } from '@aws-sdk/client-iam'
+import { AddPermissionCommand, CreateFunctionCommand, GetFunctionConfigurationCommand, InvokeCommand, LambdaClient, UpdateFunctionCodeCommand, UpdateFunctionConfigurationCommand } from '@aws-sdk/client-lambda'
+import { PutObjectCommand, S3Client } from '@aws-sdk/client-s3'
+import bytes from 'bytes'
+import parseArn from 'aws-arn-parser'
+import { nanoid } from 'nanoid'
+import pRetry from 'p-retry'
+import revHash from 'rev-hash'
 
-const UserError = require('./user-error')
+import UserError from './user-error.js'
 
 const lambda = new LambdaClient()
 const apiGatewayV1 = new APIGatewayClient()
@@ -40,7 +40,7 @@ function addPermission ({ lambdaArn, restApiId }) {
   return lambda.send(new AddPermissionCommand(params))
 }
 
-exports.verifyCodeSize = function (zipFile, { usingS3 }) {
+export function verifyCodeSize (zipFile, { usingS3 }) {
   const codeStorageName = (usingS3 ? 'S3' : 'Lambda')
   const fileSizeLimit = (usingS3 ? MAX_S3_ZIP_SIZE : MAX_LAMBDA_ZIP_SIZE)
   const hint = (usingS3 ? '' : ', use --bucket to use S3')
@@ -48,7 +48,7 @@ exports.verifyCodeSize = function (zipFile, { usingS3 }) {
   if (zipFile.byteLength >= fileSizeLimit) throw new Error(`Code size exceeded, ${bytes.format(zipFile.byteLength)}, max zip size for ${codeStorageName} deployments is ${bytes.format(fileSizeLimit)}${hint}`)
 }
 
-exports.createFunction = function ({ code, functionName, handler, role, environment, onFailedAttempt }) {
+export async function createFunction ({ code, functionName, handler, role, environment, onFailedAttempt }) {
   const params = {
     Code: code,
     Environment: (environment ? { Variables: environment } : undefined),
@@ -61,20 +61,20 @@ exports.createFunction = function ({ code, functionName, handler, role, environm
     Timeout: defaultParams.Timeout
   }
 
-  return pRetry(() => lambda.send(new CreateFunctionCommand(params)), { minTimeout: 2000, factor: 3, retries: 5, onFailedAttempt }).then(res => res.FunctionArn)
+  return (await pRetry(async () => await lambda.send(new CreateFunctionCommand(params)), { minTimeout: 2000, factor: 3, retries: 5, onFailedAttempt })).FunctionArn
 }
 
-function updateRuntime ({ functionName, handler }) {
+async function updateRuntime ({ functionName, handler }) {
   const params = {
     FunctionName: functionName,
     Handler: handler,
     Runtime: defaultParams.Runtime
   }
 
-  return lambda.send(new UpdateFunctionConfigurationCommand(params)).then(res => res.FunctionArn)
+  return (await lambda.send(new UpdateFunctionConfigurationCommand(params))).FunctionArn
 }
 
-exports.updateFunction = async function ({ code, functionName, handler }) {
+export async function updateFunction ({ code, functionName, handler }) {
   const params = {
     FunctionName: functionName,
     Publish: true,
@@ -90,24 +90,26 @@ exports.updateFunction = async function ({ code, functionName, handler }) {
   return result.FunctionArn
 }
 
-exports.getFunctionEnvironment = function ({ functionName }) {
+export async function getFunctionEnvironment ({ functionName }) {
   const params = {
     FunctionName: functionName
   }
 
-  return lambda.send(new GetFunctionConfigurationCommand(params)).then(res => (res.Environment && res.Environment.Variables) || {})
+  const result = await lambda.send(new GetFunctionConfigurationCommand(params))
+
+  return (result.Environment && result.Environment.Variables) || {}
 }
 
-exports.updateFunctionEnvironment = function ({ functionName, environment }) {
+export async function updateFunctionEnvironment ({ functionName, environment }) {
   const params = {
     FunctionName: functionName,
     Environment: { Variables: environment }
   }
 
-  return lambda.send(new UpdateFunctionConfigurationCommand(params)).then(res => res.FunctionArn)
+  return (await lambda.send(new UpdateFunctionConfigurationCommand(params))).FunctionArn
 }
 
-exports.createApiGateway = async function ({ definition, lambdaArn }) {
+export async function createApiGateway ({ definition, lambdaArn }) {
   const params = {
     Body: JSON.stringify(definition),
     FailOnWarnings: true
@@ -120,7 +122,7 @@ exports.createApiGateway = async function ({ definition, lambdaArn }) {
   return result.ApiId
 }
 
-exports.findApiGateway = async function (name) {
+export async function findApiGateway (name) {
   const result = await apiGatewayV2.send(new GetApisCommand({ MaxResults: '500' }))
 
   if (result.Items.length === 500) {
@@ -140,7 +142,7 @@ exports.findApiGateway = async function (name) {
   return matches[0].ApiId
 }
 
-exports.updateApiGatewayV1 = async function ({ id, definition, lambdaArn }) {
+export async function updateApiGatewayV1 ({ id, definition, lambdaArn }) {
   const params = {
     body: JSON.stringify(definition),
     restApiId: id,
@@ -155,7 +157,7 @@ exports.updateApiGatewayV1 = async function ({ id, definition, lambdaArn }) {
   return result
 }
 
-exports.updateApiGatewayV2 = async function ({ id, definition, lambdaArn }) {
+export async function updateApiGatewayV2 ({ id, definition, lambdaArn }) {
   const params = {
     ApiId: id,
     Body: JSON.stringify(definition),
@@ -169,16 +171,16 @@ exports.updateApiGatewayV2 = async function ({ id, definition, lambdaArn }) {
   return result
 }
 
-exports.deployApiGatewayV1 = function ({ id, stage }) {
+export async function deployApiGatewayV1 ({ id, stage }) {
   const params = {
     restApiId: id,
     stageName: stage
   }
 
-  return apiGatewayV1.send(new CreateDeploymentCommandV1(params))
+  return await apiGatewayV1.send(new CreateDeploymentCommandV1(params))
 }
 
-exports.deployApiGatewayV2 = async function ({ id, stage }) {
+export async function deployApiGatewayV2 ({ id, stage }) {
   try {
     await apiGatewayV2.send(new CreateDeploymentCommandV2({ ApiId: id, StageName: stage }))
   } catch (originalError) {
@@ -201,7 +203,7 @@ const assumeRolePolicy = JSON.stringify({
   }]
 })
 
-exports.createLambdaRole = async function (name) {
+export async function createLambdaRole (name) {
   const createParams = {
     AssumeRolePolicyDocument: assumeRolePolicy,
     Path: '/',
@@ -223,7 +225,7 @@ exports.createLambdaRole = async function (name) {
   return result.Role.Arn
 }
 
-exports.uploadToS3 = async function ({ zipFile, functionName, bucketName }) {
+export async function uploadToS3 ({ zipFile, functionName, bucketName }) {
   const key = `${functionName}-${revHash(zipFile)}.zip`
 
   const params = {
@@ -237,7 +239,7 @@ exports.uploadToS3 = async function ({ zipFile, functionName, bucketName }) {
   return key
 }
 
-exports.invokeLambda = async function ({ functionName, payload }) {
+export async function invokeLambda ({ functionName, payload }) {
   const params = {
     FunctionName: functionName,
     InvocationType: 'RequestResponse',

--- a/lib/builder.js
+++ b/lib/builder.js
@@ -1,32 +1,35 @@
-const fs = require('fs')
-const path = require('path')
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
 
-const bytes = require('bytes')
-const cpFile = require('cp-file')
-const execa = require('execa')
-const gitignoreToDockerignore = require('gitignore-to-dockerignore')
-const loadJsonFile = require('load-json-file')
-const loadTextFile = require('load-text-file')
-const pathExists = require('path-exists')
-const rmFile = require('rm-file')
-const unload = require('unload')
-const writeFile = require('write-file-atomically')
+import bytes from 'bytes'
+import cpFile from 'cp-file'
+import execa from 'execa'
+import gitignoreToDockerignore from 'gitignore-to-dockerignore'
+import loadJsonFile from 'load-json-file'
+import { loadTextFile } from 'load-text-file'
+import { pathExists } from 'path-exists'
+import { rmFileSync } from 'rm-file'
+import unload from 'unload'
+import writeFile from 'write-file-atomically'
 
-const dockerfile = require('./dockerfile')
+import { generateDockerfile } from './dockerfile.js'
+
+const dirname = path.dirname(fileURLToPath(import.meta.url))
 
 function writeJsonFile (path, data) {
   return writeFile(path, JSON.stringify(data, null, 2) + '\n')
 }
 
-function loadGitignoreFile (path) {
-  return loadTextFile(path).then(gitignoreToDockerignore)
+async function loadGitignoreFile (path) {
+  return gitignoreToDockerignore(await loadTextFile(path))
 }
 
 const DEFAULT_IGNORE = ['.git/', 'node_modules/'].join('\n') + '\n'
 
-exports.createZipFile = async function (directory, { customEntrypoint, skipNodeModules, sshKey }) {
+export async function createZipFile (directory, { customEntrypoint, skipNodeModules, sshKey }) {
   const cleanupFiles = []
-  const cleanup = () => cleanupFiles.map(file => path.join(directory, file)).forEach(rmFile.sync)
+  const cleanup = () => cleanupFiles.map(file => path.join(directory, file)).forEach(rmFileSync)
   const removeUnloadCleanupHandler = unload.add(cleanup)
 
   const hasYarnLockfile = await pathExists(path.join(directory, 'yarn.lock'))
@@ -40,7 +43,7 @@ exports.createZipFile = async function (directory, { customEntrypoint, skipNodeM
   const hasBuildScript = Boolean(packageInfo.scripts && packageInfo.scripts.build)
   const hasPrepareScript = Boolean(packageInfo.scripts && packageInfo.scripts.prepare)
   const hasProductionDependencies = Boolean(packageInfo.dependencies && Object.keys(packageInfo.dependencies).length)
-  const dockerfileSource = dockerfile.generate({ hasBuildScript, hasPrepareScript, hasProductionDependencies, skipNodeModules, sshKey: Boolean(sshKey), yarn: hasYarnLockfile })
+  const dockerfileSource = generateDockerfile({ hasBuildScript, hasPrepareScript, hasProductionDependencies, skipNodeModules, sshKey: Boolean(sshKey), yarn: hasYarnLockfile })
 
   const hasDockerignore = await pathExists(path.join(directory, '.dockerignore'))
   const hasGitignore = await pathExists(path.join(directory, '.gitignore'))
@@ -49,7 +52,7 @@ exports.createZipFile = async function (directory, { customEntrypoint, skipNodeM
   cleanupFiles.push('scandium-dockerfile')
 
   if (!customEntrypoint) {
-    await cpFile(path.join(__dirname, '../entrypoint.js'), path.join(directory, 'scandium-entrypoint.js'))
+    await cpFile(path.join(dirname, '../entrypoint.js'), path.join(directory, 'scandium-entrypoint.js'))
     cleanupFiles.push('scandium-entrypoint.js')
   }
 
@@ -71,15 +74,15 @@ exports.createZipFile = async function (directory, { customEntrypoint, skipNodeM
   if (sshKey) {
     const sshKeyPrivate = fs.readFileSync(sshKey).toString('base64')
     const sshKeyPublic = fs.readFileSync(`${sshKey}.pub`).toString('base64')
-    imageId = await execa.stdout('docker', ['build', '--platform', 'linux/amd64', '--quiet', '--build-arg', 'SSH_PRIVATE_KEY', '--build-arg', 'SSH_PUBLIC_KEY', '--file', 'scandium-dockerfile', '.'], { cwd: directory, env: { SSH_PRIVATE_KEY: sshKeyPrivate, SSH_PUBLIC_KEY: sshKeyPublic } })
+    imageId = (await execa('docker', ['build', '--platform', 'linux/amd64', '--quiet', '--build-arg', 'SSH_PRIVATE_KEY', '--build-arg', 'SSH_PUBLIC_KEY', '--file', 'scandium-dockerfile', '.'], { cwd: directory, env: { SSH_PRIVATE_KEY: sshKeyPrivate, SSH_PUBLIC_KEY: sshKeyPublic } })).stdout
   } else {
-    imageId = await execa.stdout('docker', ['build', '--platform', 'linux/amd64', '--quiet', '--file', 'scandium-dockerfile', '.'], { cwd: directory })
+    imageId = (await execa('docker', ['build', '--platform', 'linux/amd64', '--quiet', '--file', 'scandium-dockerfile', '.'], { cwd: directory })).stdout
   }
 
   cleanup()
   removeUnloadCleanupHandler()
 
-  const zipFile = await execa.stdout('docker', ['run', '--platform', 'linux/amd64', '--rm', imageId], { maxBuffer: bytes.parse('134mb') })
+  const zipFile = (await execa('docker', ['run', '--platform', 'linux/amd64', '--rm', imageId], { maxBuffer: bytes.parse('134mb') })).stdout
 
   return Buffer.from(zipFile, 'base64')
 }

--- a/lib/dockerfile.js
+++ b/lib/dockerfile.js
@@ -25,7 +25,7 @@ const listNpmPackFiles = (
  * @param {boolean} options.yarn
  * @returns {string}
  */
-exports.generate = function (options) {
+export function generateDockerfile (options) {
   const { hasBuildScript, hasPrepareScript, hasProductionDependencies, skipNodeModules, sshKey, yarn } = options
   const lines = []
 

--- a/lib/swagger.js
+++ b/lib/swagger.js
@@ -1,6 +1,6 @@
-const loadJsonFile = require('load-json-file')
-const loadYamlFile = require('load-yaml-file')
-const parseArn = require('aws-arn-parser')
+import parseArn from 'aws-arn-parser'
+import loadJsonFile from 'load-json-file'
+import { loadYamlFile } from 'load-yaml-file'
 
 const BINARY_MEDIA_TYPES = [
   '*/*'
@@ -28,7 +28,7 @@ function integrationV1 (lambdaArn) {
   }
 }
 
-exports.loadSwaggerFileV1 = async function (filename, name, lambdaArn) {
+export async function loadSwaggerFileV1 (filename, name, lambdaArn) {
   const packageInfo = await loadJsonFile('package.json')
   const definition = await loadYamlFile(filename)
 
@@ -55,7 +55,7 @@ exports.loadSwaggerFileV1 = async function (filename, name, lambdaArn) {
   return definition
 }
 
-exports.forwardAllDefinitionV1 = async function (name, lambdaArn) {
+export async function forwardAllDefinitionV1 (name, lambdaArn) {
   const packageInfo = await loadJsonFile('package.json')
 
   return {
@@ -92,7 +92,7 @@ function integrationV2 (lambdaArn) {
   }
 }
 
-exports.loadSwaggerFileV2 = async function (filename, name, lambdaArn) {
+export async function loadSwaggerFileV2 (filename, name, lambdaArn) {
   const packageInfo = await loadJsonFile('package.json')
   const definition = await loadYamlFile(filename)
 
@@ -119,7 +119,7 @@ exports.loadSwaggerFileV2 = async function (filename, name, lambdaArn) {
   return definition
 }
 
-exports.forwardAllDefinitionV2 = async function (name, lambdaArn) {
+export async function forwardAllDefinitionV2 (name, lambdaArn) {
   const packageInfo = await loadJsonFile('package.json')
 
   return {

--- a/lib/tasks.js
+++ b/lib/tasks.js
@@ -1,19 +1,19 @@
-const fs = require('fs')
-const path = require('path')
-const util = require('util')
+import fs from 'node:fs'
+import path from 'node:path'
+import util from 'node:util'
 
-const amendObject = require('amend-object')
-const dotenv = require('dotenv')
-const loadJsonFile = require('load-json-file')
-const parseArn = require('aws-arn-parser')
-const parseKeyValuePair = require('parse-key-value-pair')
-const bytes = require('bytes')
-const formatDuration = require('format-duration')
+import amendObject from 'amend-object'
+import dotenv from 'dotenv'
+import loadJsonFile from 'load-json-file'
+import parseArn from 'aws-arn-parser'
+import parseKeyValuePair from 'parse-key-value-pair'
+import bytes from 'bytes'
+import formatDuration from 'format-duration'
 
-const amazon = require('./amazon')
-const builder = require('./builder')
-const swagger = require('./swagger')
-const UserError = require('./user-error')
+import * as amazon from './amazon.js'
+import * as builder from './builder.js'
+import * as swagger from './swagger.js'
+import UserError from './user-error.js'
 
 const readFile = util.promisify(fs.readFile)
 const writeFile = util.promisify(fs.writeFile)
@@ -22,7 +22,7 @@ const DEFAULT_ENVIRONMENT = {
   NODE_ENV: 'production'
 }
 
-exports.parseOptions = {
+export const parseOptions = {
   title: 'Parse options',
   task: async (ctx, task) => {
     if (ctx.args['--name']) {
@@ -78,7 +78,7 @@ exports.parseOptions = {
   }
 }
 
-exports.packageApp = {
+export const packageApp = {
   title: 'Packaging app for Lambda',
   task: async (ctx, task) => {
     const startedAt = Date.now()
@@ -98,7 +98,7 @@ exports.packageApp = {
   }
 }
 
-exports.saveApp = {
+export const saveApp = {
   title: 'Saving packaged app',
   enabled: (ctx) => Boolean(ctx.outputPath) && !ctx.dryRun,
   task: async (ctx, task) => {
@@ -110,7 +110,7 @@ exports.saveApp = {
   }
 }
 
-exports.verifyCodeSize = {
+export const verifyCodeSize = {
   title: 'Verify code size',
   task: async (ctx, task) => {
     if (!ctx.code) throw new Error('Missing ctx.code')
@@ -120,7 +120,7 @@ exports.verifyCodeSize = {
   }
 }
 
-exports.uploadToS3 = {
+export const uploadToS3 = {
   title: 'Uploading zip to S3',
   enabled: (ctx) => Boolean(ctx.bucket) && !ctx.dryRun,
   task: async (ctx, task) => {
@@ -132,7 +132,7 @@ exports.uploadToS3 = {
   }
 }
 
-exports.createLambdaRole = {
+export const createLambdaRole = {
   title: 'Creating Lambda role',
   enabled: (ctx) => !ctx.dryRun,
   task: async (ctx, task) => {
@@ -146,7 +146,7 @@ exports.createLambdaRole = {
   }
 }
 
-exports.createLambdaFunction = {
+export const createLambdaFunction = {
   title: 'Creating Lambda function',
   enabled: (ctx) => !ctx.dryRun,
   task: async (ctx, task) => {
@@ -159,7 +159,7 @@ exports.createLambdaFunction = {
   }
 }
 
-exports.updateLambdaFunction = {
+export const updateLambdaFunction = {
   title: 'Updating Lambda function',
   enabled: (ctx) => !ctx.dryRun,
   task: async (ctx, task) => {
@@ -176,7 +176,7 @@ exports.updateLambdaFunction = {
   }
 }
 
-exports.updateLambdaEnvironment = {
+export const updateLambdaEnvironment = {
   title: 'Update Lambda environment',
   enabled: (ctx) => Boolean(ctx.args['--env-from-file'] || ctx.args['--env']) && !ctx.dryRun,
   task: async (ctx, task) => {
@@ -188,7 +188,7 @@ exports.updateLambdaEnvironment = {
   }
 }
 
-exports.invokeHooks = {
+export const invokeHooks = {
   title: 'Invoke hooks',
   enabled: (ctx) => Boolean(ctx.args['--hooks']) && !ctx.dryRun,
   task: async (ctx, task) => {
@@ -198,7 +198,7 @@ exports.invokeHooks = {
   }
 }
 
-exports.loadSwaggerDefinition = {
+export const loadSwaggerDefinition = {
   title: 'Load Swagger definition',
   enabled: (ctx) => !ctx.args['--no-api-gateway'] && Boolean(ctx.args['--swagger']) && !ctx.dryRun,
   task: async (ctx, task) => {
@@ -212,7 +212,7 @@ exports.loadSwaggerDefinition = {
   }
 }
 
-exports.generateSwaggerDefinition = {
+export const generateSwaggerDefinition = {
   title: 'Generate Swagger definition',
   enabled: (ctx) => !ctx.args['--no-api-gateway'] && !ctx.args['--swagger'] && !ctx.dryRun,
   task: async (ctx, task) => {
@@ -226,7 +226,7 @@ exports.generateSwaggerDefinition = {
   }
 }
 
-exports.createApiGateway = {
+export const createApiGateway = {
   title: 'Creating new API Gateway',
   enabled: (ctx) => !ctx.args['--no-api-gateway'] && !ctx.dryRun,
   task: async (ctx, task) => {
@@ -240,7 +240,7 @@ exports.createApiGateway = {
   }
 }
 
-exports.updateApiGateway = {
+export const updateApiGateway = {
   title: 'Updating existing API Gateway',
   enabled: (ctx) => !ctx.args['--no-api-gateway'] && !ctx.dryRun,
   task: async (ctx, task) => {
@@ -267,7 +267,7 @@ exports.updateApiGateway = {
   }
 }
 
-exports.deployApi = {
+export const deployApi = {
   title: 'Deploying the API to a live address',
   enabled: (ctx) => !ctx.args['--no-api-gateway'] && !ctx.dryRun,
   task: async (ctx, task) => {
@@ -287,7 +287,7 @@ exports.deployApi = {
   }
 }
 
-exports.getCurrentEnvironment = {
+export const getCurrentEnvironment = {
   title: 'Fetching current environment',
   enabled: (ctx) => Boolean(ctx.args['--env-from-file'] || ctx.args['--env'] || ctx.args.environment),
   task: async (ctx, task) => {

--- a/lib/user-error.js
+++ b/lib/user-error.js
@@ -1,1 +1,1 @@
-module.exports = class UserError extends Error {}
+export default class UserError extends Error {}

--- a/package.json
+++ b/package.json
@@ -3,8 +3,9 @@
   "version": "1.0.0-alpha.56",
   "license": "MIT",
   "repository": "LinusU/scandium",
+  "type": "module",
   "bin": {
-    "scandium": "app.js"
+    "scandium": "./app.js"
   },
   "scripts": {
     "test": "standard"
@@ -15,32 +16,35 @@
     "@aws-sdk/client-iam": "^3.25.0",
     "@aws-sdk/client-lambda": "^3.25.0",
     "@aws-sdk/client-s3": "^3.25.0",
-    "amend-object": "^1.0.0",
+    "amend-object": "^2.0.0",
     "aws-arn-parser": "^1.0.0",
     "aws-has-region": "^2.0.1",
     "bytes": "^3.0.0",
-    "cp-file": "^6.0.0",
+    "cp-file": "^9.1.0",
     "dotenv": "^10.0.0",
-    "execa": "^0.10.0",
-    "format-duration": "^1.1.0",
-    "gitignore-to-dockerignore": "^1.0.0",
-    "is-ci": "^1.1.0",
-    "listr": "^0.14.1",
-    "listr-verbose-renderer": "^0.4.1",
-    "load-json-file": "^5.0.0",
-    "load-text-file": "^1.1.0",
-    "load-yaml-file": "^0.1.0",
-    "nanoid": "^3.1.9",
-    "neodoc": "^2.0.0",
-    "p-retry": "^2.0.0",
+    "execa": "^5.1.1",
+    "format-duration": "^1.4.0",
+    "gitignore-to-dockerignore": "^2.0.0",
+    "is-ci": "^3.0.0",
+    "listr": "^0.14.3",
+    "listr-verbose-renderer": "^0.6.0",
+    "load-json-file": "^6.0.0",
+    "load-text-file": "^2.0.0",
+    "load-yaml-file": "^1.0.0",
+    "nanoid": "^3.1.25",
+    "neodoc": "^2.0.2",
+    "p-retry": "^4.6.1",
     "parse-key-value-pair": "^1.1.1",
-    "path-exists": "^3.0.0",
-    "rev-hash": "^2.0.0",
-    "rm-file": "^1.2.0",
+    "path-exists": "^5.0.0",
+    "rev-hash": "^3.0.0",
+    "rm-file": "^2.0.0",
     "unload": "^1.3.6",
     "write-file-atomically": "^2.0.0"
   },
   "devDependencies": {
-    "standard": "^14.3.3"
+    "standard": "^16.0.3"
+  },
+  "engines": {
+    "node": "^14.13.1 || >=16.0.0"
   }
 }


### PR DESCRIPTION
Migration Guide:

This relases changes the package from a Common JS module to an EcmaScript module, and drops support for older versions of Node.

- The minimum version of Node.js supported is now: `14.13.1`, and `16.0.0`