### PR TITLE
💥 Add support for ESM

### DIFF
--- a/entrypoint.js
+++ b/entrypoint.js
@@ -1,7 +1,7 @@
-const net = require('net')
-const url = require('url')
-const http = require('http')
-const stream = require('stream')
+import net from 'node:net'
+import url from 'node:url'
+import http from 'node:http'
+import stream from 'node:stream'
 
 const kChunks = Symbol('chunks')
 const kCallback = Symbol('callback')
@@ -169,7 +169,7 @@ const serverPromise = new Promise((resolve) => {
   }
 })
 
-exports.handler = function (event, context, cb) {
+export function handler (event, context, cb) {
   // Lambda will try and wait for the event loop to exhaust. In a web server
   // that typically won't happen because of connection pools to the database,
   // open connections to external services, etc. Tell Lambda to complete the
@@ -178,7 +178,7 @@ exports.handler = function (event, context, cb) {
 
   if (event.scandiumInvokeHook) {
     Promise.resolve()
-      .then(() => require('./' + event.scandiumInvokeHook.file))
+      .then(() => import('./' + event.scandiumInvokeHook.file))
       .then((hooks) => hooks[event.scandiumInvokeHook.hook]())
       .then(() => cb(null), (err) => cb(err))
 
@@ -193,4 +193,4 @@ exports.handler = function (event, context, cb) {
 }
 
 // Start the actual app
-require('./')
+await import('{{MAIN_FILE}}')

--- a/lib/builder.js
+++ b/lib/builder.js
@@ -3,7 +3,6 @@ import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 import bytes from 'bytes'
-import cpFile from 'cp-file'
 import execa from 'execa'
 import temp from 'fs-temp/promises'
 import gitignoreToDockerignore from 'gitignore-to-dockerignore'
@@ -53,8 +52,10 @@ export async function createZipFile (directory, { customEntrypoint, skipNodeModu
   await writeFile(dockerfilePath, dockerfileSource)
 
   if (!customEntrypoint) {
-    await cpFile(path.join(dirname, '../entrypoint.js'), path.join(directory, 'scandium-entrypoint.js'))
-    cleanupFiles.push('scandium-entrypoint.js')
+    let entrypoint = await loadTextFile(path.join(dirname, '../entrypoint.js'))
+    entrypoint = entrypoint.replace('{{MAIN_FILE}}', packageInfo.main || 'index.js')
+    await writeFile(path.join(directory, 'scandium-entrypoint.mjs'), entrypoint)
+    cleanupFiles.push('scandium-entrypoint.mjs')
   }
 
   await writeJsonFile(path.join(directory, 'scandium-clean-package.json'), cleanPackageInfo)

--- a/lib/dockerfile.js
+++ b/lib/dockerfile.js
@@ -7,10 +7,10 @@ const listNpmPackFiles = (
   'JSON.parse(child_process.execSync("npm pack --dry-run --json").toString())' +
   // Extract list of files from output
   '[0].files.map(file => file.path)' +
-  // Remove "scandium-entrypoint.js" if it exists
-  '.filter(path => path !== "scandium-entrypoint.js")' +
-  // Always add back "scandium-entrypoint.js"
-  '.concat(["scandium-entrypoint.js"])' +
+  // Remove "scandium-entrypoint.mjs" if it exists
+  '.filter(path => path !== "scandium-entrypoint.mjs")' +
+  // Always add back "scandium-entrypoint.mjs"
+  '.concat(["scandium-entrypoint.mjs"])' +
   // Output one line per file
   '.join("\\n")'
 )

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "aws-arn-parser": "^1.0.0",
     "aws-has-region": "^2.0.1",
     "bytes": "^3.0.0",
-    "cp-file": "^9.1.0",
     "dotenv": "^10.0.0",
     "execa": "^5.1.1",
     "format-duration": "^1.4.0",
@@ -43,7 +42,7 @@
     "write-file-atomically": "^2.0.0"
   },
   "devDependencies": {
-    "standard": "^16.0.3"
+    "standard": "^17.0.0"
   },
   "engines": {
     "node": "^16.15.0 || >=18.0.0"


### PR DESCRIPTION
Migration Guide:

This shouldn't be a breaking change for most users. But the logic for detecting the entrypoint might have changed slightly. If your entrypoint is not called `index.js`, and you haven't specified a `main` file (with extension) in `package.json`, Scandium might fail to load your app. Fix it by adding a `main` field in your `package.json` file.